### PR TITLE
device-modbus command reading process async thread can't be ended normally

### DIFF
--- a/src/main/java/org/edgexfoundry/domain/Transaction.java
+++ b/src/main/java/org/edgexfoundry/domain/Transaction.java
@@ -29,6 +29,7 @@ public class Transaction {
 	private Map<String, Boolean> opIds;
 	private Boolean finished = true;
     private Boolean isFail = false;
+    private RuntimeException failException;
 	
 	public Transaction() {
 		setTransactionId(UUID.randomUUID().toString());
@@ -82,5 +83,13 @@ public class Transaction {
     public void setFail() {
         isFail = true;
         finished = true;
+    }
+
+    public RuntimeException getFailException() {
+        return failException;
+    }
+
+    public void setFailException(RuntimeException failException) {
+        this.failException = failException;
     }
 }

--- a/src/main/java/org/edgexfoundry/domain/Transaction.java
+++ b/src/main/java/org/edgexfoundry/domain/Transaction.java
@@ -19,19 +19,16 @@
  *******************************************************************************/
 package org.edgexfoundry.domain;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
 import org.edgexfoundry.domain.core.Reading;
+
+import java.util.*;
 
 public class Transaction {	
 	private String transactionId;
 	private List<Reading> readings;
 	private Map<String, Boolean> opIds;
 	private Boolean finished = true;
+    private Boolean isFail = false;
 	
 	public Transaction() {
 		setTransactionId(UUID.randomUUID().toString());
@@ -78,4 +75,12 @@ public class Transaction {
 			this.readings.addAll(readings);
 	}
 
+    public Boolean isFail() {
+        return isFail;
+    }
+
+    public void setFail() {
+        isFail = true;
+        finished = true;
+    }
 }

--- a/src/main/java/org/edgexfoundry/handler/ModbusHandler.java
+++ b/src/main/java/org/edgexfoundry/handler/ModbusHandler.java
@@ -45,6 +45,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.math.BigInteger;
+import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -135,7 +136,7 @@ public class ModbusHandler {
 				}
 			}
 			if (transactions.get(transactionId).isFail()) {
-				throw new BadCommandRequestException("ModbusDriver process error .");
+                throw transactions.get(transactionId).getFailException();
 			}
 		}
 	
@@ -318,9 +319,10 @@ public class ModbusHandler {
 		}
 	}
 
-	public void failTransaction(String transactionId) {
+    public void failTransaction(String transactionId, RuntimeException e) {
 		synchronized (transactions) {
 			transactions.get(transactionId).setFail();
+            transactions.get(transactionId).setFailException(e);
 			transactions.notifyAll();
 		}
 	}

--- a/src/main/java/org/edgexfoundry/modbus/ModbusConnection.java
+++ b/src/main/java/org/edgexfoundry/modbus/ModbusConnection.java
@@ -28,6 +28,7 @@ import org.edgexfoundry.domain.ModbusObject;
 import org.edgexfoundry.domain.meta.Addressable;
 import org.edgexfoundry.domain.meta.Protocol;
 import org.edgexfoundry.exception.BadCommandRequestException;
+import org.edgexfoundry.exception.ServiceException;
 import org.edgexfoundry.support.logging.client.EdgeXLogger;
 import org.edgexfoundry.support.logging.client.EdgeXLoggerFactory;
 
@@ -170,7 +171,7 @@ public class ModbusConnection {
 			catch(Exception e){
 				logger.error("General Exception e:" + e.getMessage());
 
-				throw new BadCommandRequestException(e.getMessage());
+				throw new ServiceException(e);
 			}
 			finally{
 				con.close();

--- a/src/main/java/org/edgexfoundry/modbus/ModbusConnection.java
+++ b/src/main/java/org/edgexfoundry/modbus/ModbusConnection.java
@@ -171,7 +171,7 @@ public class ModbusConnection {
 			catch(Exception e){
 				logger.error("General Exception e:" + e.getMessage());
 
-				throw new ServiceException(e);
+                throw new BadCommandRequestException(e.getMessage());
 			}
 			finally{
 				con.close();

--- a/src/main/java/org/edgexfoundry/modbus/ModbusDriver.java
+++ b/src/main/java/org/edgexfoundry/modbus/ModbusDriver.java
@@ -66,10 +66,17 @@ public class ModbusDriver {
 		String result = "";
 		
 		// TODO 2: [Optional] Modify this processCommand call to pass any additional required metadata from the profile to the driver stack
-		result = processCommand(operation.getOperation(), device.getAddressable(), object, value);
-		logger.info("Putting result:" + result);
-		objectCache.put(device, operation, result);
-		handler.completeTransaction(transactionId, opId, objectCache.getResponses(device, operation));
+        try {
+            result = processCommand(operation.getOperation(), device.getAddressable(), object, value);
+            logger.info("Putting result:" + result);
+            objectCache.put(device, operation, result);
+            handler.completeTransaction(transactionId, opId, objectCache.getResponses(device, operation));
+        } catch (Exception e) {
+            logger.error("ModbusDriver process Exception e:" + e.getMessage());
+            handler.failTransaction(transactionId);
+            Thread.currentThread().interrupt();
+        }
+
 	}
 
 	// Modify this function as needed to pass necessary metadata from the device and its profile to the driver interface

--- a/src/main/java/org/edgexfoundry/modbus/ModbusDriver.java
+++ b/src/main/java/org/edgexfoundry/modbus/ModbusDriver.java
@@ -28,6 +28,7 @@ import org.edgexfoundry.domain.ScanList;
 import org.edgexfoundry.domain.meta.Addressable;
 import org.edgexfoundry.domain.meta.Device;
 import org.edgexfoundry.domain.meta.ResourceOperation;
+import org.edgexfoundry.exception.ServiceException;
 import org.edgexfoundry.handler.ModbusHandler;
 import org.edgexfoundry.support.logging.client.EdgeXLogger;
 import org.edgexfoundry.support.logging.client.EdgeXLoggerFactory;
@@ -73,7 +74,7 @@ public class ModbusDriver {
             handler.completeTransaction(transactionId, opId, objectCache.getResponses(device, operation));
         } catch (Exception e) {
             logger.error("ModbusDriver process Exception e:" + e.getMessage());
-            handler.failTransaction(transactionId);
+			handler.failTransaction(transactionId, new ServiceException(e));
             Thread.currentThread().interrupt();
         }
 

--- a/src/main/resources/rest-endpoint.properties
+++ b/src/main/resources/rest-endpoint.properties
@@ -18,39 +18,20 @@
 # @version: 1.0.0
 ###############################################################################
 #------------------- REST Endpoints ---------------------------------------
-## metadata database service connection information
-#meta.db.addressable.url=http://edgex-core-metadata:48081/api/v1/addressable
-#meta.db.deviceservice.url=http://edgex-core-metadata:48081/api/v1/deviceservice
-#meta.db.deviceprofile.url=http://edgex-core-metadata:48081/api/v1/deviceprofile
-#meta.db.device.url=http://edgex-core-metadata:48081/api/v1/device
-#meta.db.devicereport.url=http://edgex-core-metadata:48081/api/v1/devicereport
-#meta.db.command.url=http://edgex-core-metadata:48081/api/v1/command
-#meta.db.event.url=http://edgex-core-metadata:48081/api/v1/scheduleevent
-#meta.db.schedule.url=http://edgex-core-metadata:48081/api/v1/schedule
-#meta.db.provisionwatcher.url=http://edgex-core-metadata:48081/api/v1/provisionwatcher
-#meta.db.ping.url=http://edgex-core-metadata:48081/api/v1/ping
-#
-##IOT core database service connection information
-#core.db.event.url=http://edgex-core-data:48080/api/v1/event
-#core.db.reading.url=http://edgex-core-data:48080/api/v1/reading
-#core.db.valuedescriptor.url=http://edgex-core-data:48080/api/v1/valuedescriptor
-#core.db.ping.url=http://edgex-core-data:48080/api/v1/ping
-
 # metadata database service connection information
-meta.db.addressable.url=http://localhost:48081/api/v1/addressable
-meta.db.deviceservice.url=http://localhost:48081/api/v1/deviceservice
-meta.db.deviceprofile.url=http://localhost:48081/api/v1/deviceprofile
-meta.db.device.url=http://localhost:48081/api/v1/device
-meta.db.devicereport.url=http://localhost:48081/api/v1/devicereport
-meta.db.command.url=http://localhost:48081/api/v1/command
-meta.db.event.url=http://localhost:48081/api/v1/scheduleevent
-meta.db.schedule.url=http://localhost:48081/api/v1/schedule
-meta.db.provisionwatcher.url=http://localhost:48081/api/v1/provisionwatcher
-meta.db.ping.url=http://localhost:48081/api/v1/ping
+meta.db.addressable.url=http://edgex-core-metadata:48081/api/v1/addressable
+meta.db.deviceservice.url=http://edgex-core-metadata:48081/api/v1/deviceservice
+meta.db.deviceprofile.url=http://edgex-core-metadata:48081/api/v1/deviceprofile
+meta.db.device.url=http://edgex-core-metadata:48081/api/v1/device
+meta.db.devicereport.url=http://edgex-core-metadata:48081/api/v1/devicereport
+meta.db.command.url=http://edgex-core-metadata:48081/api/v1/command
+meta.db.event.url=http://edgex-core-metadata:48081/api/v1/scheduleevent
+meta.db.schedule.url=http://edgex-core-metadata:48081/api/v1/schedule
+meta.db.provisionwatcher.url=http://edgex-core-metadata:48081/api/v1/provisionwatcher
+meta.db.ping.url=http://edgex-core-metadata:48081/api/v1/ping
 
 #IOT core database service connection information
-core.db.event.url=http://localhost:48080/api/v1/event
-core.db.reading.url=http://localhost:48080/api/v1/reading
-core.db.valuedescriptor.url=http://localhost:48080/api/v1/valuedescriptor
-core.db.ping.url=http://localhost:48080/api/v1/ping
-logging.remote.url=http://localhost:48061/api/v1/logs
+core.db.event.url=http://edgex-core-data:48080/api/v1/event
+core.db.reading.url=http://edgex-core-data:48080/api/v1/reading
+core.db.valuedescriptor.url=http://edgex-core-data:48080/api/v1/valuedescriptor
+core.db.ping.url=http://edgex-core-data:48080/api/v1/ping

--- a/src/main/resources/rest-endpoint.properties
+++ b/src/main/resources/rest-endpoint.properties
@@ -18,20 +18,39 @@
 # @version: 1.0.0
 ###############################################################################
 #------------------- REST Endpoints ---------------------------------------
+## metadata database service connection information
+#meta.db.addressable.url=http://edgex-core-metadata:48081/api/v1/addressable
+#meta.db.deviceservice.url=http://edgex-core-metadata:48081/api/v1/deviceservice
+#meta.db.deviceprofile.url=http://edgex-core-metadata:48081/api/v1/deviceprofile
+#meta.db.device.url=http://edgex-core-metadata:48081/api/v1/device
+#meta.db.devicereport.url=http://edgex-core-metadata:48081/api/v1/devicereport
+#meta.db.command.url=http://edgex-core-metadata:48081/api/v1/command
+#meta.db.event.url=http://edgex-core-metadata:48081/api/v1/scheduleevent
+#meta.db.schedule.url=http://edgex-core-metadata:48081/api/v1/schedule
+#meta.db.provisionwatcher.url=http://edgex-core-metadata:48081/api/v1/provisionwatcher
+#meta.db.ping.url=http://edgex-core-metadata:48081/api/v1/ping
+#
+##IOT core database service connection information
+#core.db.event.url=http://edgex-core-data:48080/api/v1/event
+#core.db.reading.url=http://edgex-core-data:48080/api/v1/reading
+#core.db.valuedescriptor.url=http://edgex-core-data:48080/api/v1/valuedescriptor
+#core.db.ping.url=http://edgex-core-data:48080/api/v1/ping
+
 # metadata database service connection information
-meta.db.addressable.url=http://edgex-core-metadata:48081/api/v1/addressable
-meta.db.deviceservice.url=http://edgex-core-metadata:48081/api/v1/deviceservice
-meta.db.deviceprofile.url=http://edgex-core-metadata:48081/api/v1/deviceprofile
-meta.db.device.url=http://edgex-core-metadata:48081/api/v1/device
-meta.db.devicereport.url=http://edgex-core-metadata:48081/api/v1/devicereport
-meta.db.command.url=http://edgex-core-metadata:48081/api/v1/command
-meta.db.event.url=http://edgex-core-metadata:48081/api/v1/scheduleevent
-meta.db.schedule.url=http://edgex-core-metadata:48081/api/v1/schedule
-meta.db.provisionwatcher.url=http://edgex-core-metadata:48081/api/v1/provisionwatcher
-meta.db.ping.url=http://edgex-core-metadata:48081/api/v1/ping
+meta.db.addressable.url=http://localhost:48081/api/v1/addressable
+meta.db.deviceservice.url=http://localhost:48081/api/v1/deviceservice
+meta.db.deviceprofile.url=http://localhost:48081/api/v1/deviceprofile
+meta.db.device.url=http://localhost:48081/api/v1/device
+meta.db.devicereport.url=http://localhost:48081/api/v1/devicereport
+meta.db.command.url=http://localhost:48081/api/v1/command
+meta.db.event.url=http://localhost:48081/api/v1/scheduleevent
+meta.db.schedule.url=http://localhost:48081/api/v1/schedule
+meta.db.provisionwatcher.url=http://localhost:48081/api/v1/provisionwatcher
+meta.db.ping.url=http://localhost:48081/api/v1/ping
 
 #IOT core database service connection information
-core.db.event.url=http://edgex-core-data:48080/api/v1/event
-core.db.reading.url=http://edgex-core-data:48080/api/v1/reading
-core.db.valuedescriptor.url=http://edgex-core-data:48080/api/v1/valuedescriptor
-core.db.ping.url=http://edgex-core-data:48080/api/v1/ping
+core.db.event.url=http://localhost:48080/api/v1/event
+core.db.reading.url=http://localhost:48080/api/v1/reading
+core.db.valuedescriptor.url=http://localhost:48080/api/v1/valuedescriptor
+core.db.ping.url=http://localhost:48080/api/v1/ping
+logging.remote.url=http://localhost:48061/api/v1/logs


### PR DESCRIPTION
If the Modbus command reading process encounters any exception, it will cause memory leak (the async thread can't be ended normally).